### PR TITLE
Adicionar regra de linguagem e sequência de resposta aos atendentes

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -58,9 +58,31 @@ window.submitChat = async function(t, isAudio = false) {
             volumeInstruction = "Mantenha um tom de conversa natural. Não use listas e nem textos excessivamente longos.";
         }
 
+        const attendantLanguageInstruction = [
+            "Regra obrigatória para todos os atendentes:",
+            "- Produzir frases curtas (máximo de 200 caracteres por frase).",
+            "- Manter linguagem ligada a problemas pessoais trazidos pelo paciente.",
+            "- Usar tom pessoal, informal e acolhedor.",
+            "- Preferir verbos no infinitivo pessoal quando possível.",
+            "- Falar diretamente com o paciente em segunda pessoa do singular (você).",
+            "- Avaliar o tom e a urgência emocional do paciente antes de responder.",
+            "- Seguir a sequência de interação e reiniciar o ciclo ao final:",
+            "  1) mensagem direta;",
+            "  2) mensagem com pergunta;",
+            "  3) reforço da resposta;",
+            "  4) outro reforço da resposta;",
+            "  5) reforço com pergunta;",
+            "  6) novo reforço da resposta;",
+            "  7) mensagem de preocupação;",
+            "  8) avaliar novamente o tom da necessidade do paciente e repetir o padrão."
+        ].join("\n");
+
         const messagesForAI = h.map((m, idx) => {
             if (idx === h.length - 1) {
-                return { role: m.role, content: `${m.content}\n\n[SISTEMA: ${volumeInstruction}]` };
+                return {
+                    role: m.role,
+                    content: `${m.content}\n\n[SISTEMA: ${volumeInstruction}]\n[SISTEMA: ${attendantLanguageInstruction}]`
+                };
             }
             return { role: m.role, content: m.content };
         });


### PR DESCRIPTION
### Motivation
- Garantir que as respostas geradas pelos atendentes sigam um padrão de linguagem curto, informal e dirigido ao paciente, com foco em problemas pessoais e conjugação em segunda pessoa do singular.
- Forçar uma sequência de interação (mensagem direta, pergunta, reforços, preocupação e reavaliação) para uniformizar o fluxo de atendimento automatizado.

### Description
- Adicionei em `api/generate.js` a constante `attendantLanguageInstruction` contendo as regras obrigatórias de estilo e a sequência de resposta solicitada.
- Passei a incluir essas instruções no conteúdo do último turno do usuário ao montar `messagesForAI`, concatenando-as junto à instrução de volume já existente.
- A alteração aplica-se apenas à montagem do payload enviado ao provedor de IA, preservando o histórico (`h`) e o restante da lógica de delays e armazenamento.

### Testing
- Executei checagem de sintaxe com `node --check api/generate.js`, que retornou sem erros.
- Realizei o commit das alterações com `git commit` para registrar a mudança no repositório com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699647282aa08331ac406ad6df1c7a17)