### PR TITLE
Forçar uso de GROQ_API_KEY no proxy e incluir regras de linguagem dos atendentes

### DIFF
--- a/api/generate.js
+++ b/api/generate.js
@@ -58,9 +58,31 @@ window.submitChat = async function(t, isAudio = false) {
             volumeInstruction = "Mantenha um tom de conversa natural. Não use listas e nem textos excessivamente longos.";
         }
 
+        const attendantLanguageInstruction = [
+            "Regra obrigatória para todos os atendentes:",
+            "- Produzir frases curtas (máximo de 200 caracteres por frase).",
+            "- Manter linguagem ligada a problemas pessoais trazidos pelo paciente.",
+            "- Usar tom pessoal, informal e acolhedor.",
+            "- Preferir verbos no infinitivo pessoal quando possível.",
+            "- Falar diretamente com o paciente em segunda pessoa do singular (você).",
+            "- Avaliar o tom e a urgência emocional do paciente antes de responder.",
+            "- Seguir a sequência de interação e reiniciar o ciclo ao final:",
+            "  1) mensagem direta;",
+            "  2) mensagem com pergunta;",
+            "  3) reforço da resposta;",
+            "  4) outro reforço da resposta;",
+            "  5) reforço com pergunta;",
+            "  6) novo reforço da resposta;",
+            "  7) mensagem de preocupação;",
+            "  8) avaliar novamente o tom da necessidade do paciente e repetir o padrão."
+        ].join("\n");
+
         const messagesForAI = h.map((m, idx) => {
             if (idx === h.length - 1) {
-                return { role: m.role, content: `${m.content}\n\n[SISTEMA: ${volumeInstruction}]` };
+                return {
+                    role: m.role,
+                    content: `${m.content}\n\n[SISTEMA: ${volumeInstruction}]\n[SISTEMA: ${attendantLanguageInstruction}]`
+                };
             }
             return { role: m.role, content: m.content };
         });


### PR DESCRIPTION
### Motivation
- Garantir que o proxy de IA use exclusivamente a chave da Groq (`GROQ_API_KEY`) como backend para chat completions sem fallback para outros provedores.
- Aplicar regras obrigatórias de estilo e sequência de resposta para os atendentes ao construir o payload enviado ao provedor de IA.

### Description
- Refatorei `api/ai.js` para remover o loop de provedores e operar exclusivamente com a API Groq, validando a presença de `GROQ_API_KEY` e aceitando `model` e `max_tokens` do request.
- Adicionei tratamento de erros mais informativo em `api/ai.js` para falhas HTTP e timeout, e normalizei o retorno com `choices` e `provider: 'GROQ'`.
- Inserido em `api/generate.js` a constante `attendantLanguageInstruction` contendo regras obrigatórias de estilo e sequência de interação, e concatenada essa instrução ao último turno do usuário ao montar `messagesForAI` junto com a instrução de volume.
- Mantive validações no frontend para tamanho de resposta e envio do payload ao proxy via `window.AI_PROXY_URL` com `messages`, `temperature` e `max_tokens`.

### Testing
- Executado `node --check api/ai.js` e `node --check api/generate.js`, ambos retornaram sem erros (sintaxe válida).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699647282aa08331ac406ad6df1c7a17)