### PR TITLE
Fix package.json validity for Vercel builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.vercel/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "wr-terapia-api",
   "version": "1.0.0",
+  "private": true,
   "main": "api/ai.js",
   "dependencies": {
     "node-fetch": "^2.7.0"


### PR DESCRIPTION
### Motivation
- Ensure the repository root has a strictly valid `package.json` and avoid committing local build artifacts so Vercel can parse the manifest and builds won't be disrupted.

### Description
- Added `"private": true` and normalized the root `package.json` to strict JSON, and created a `.gitignore` that excludes `node_modules/` and `.vercel/`.

### Testing
- Validated `package.json` by running `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('package.json','utf8')); console.log('package.json valid')"` and checked manifest keys with `npm pkg get name version private`, and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9caa1802c83319e34ff151ba602f6)