### PR TITLE
Fix duplicate declarations and syntax error in api/ai.js

### DIFF
--- a/api/ai.js
+++ b/api/ai.js
@@ -3,8 +3,6 @@ const fetch = require('node-fetch');
 const REQUEST_TIMEOUT_MS = 8000;
 const RAW_VERCEL_AI_URL = process.env.VERCEL_AI_URL || 'https://ai-gateway.vercel.sh/v1/chat/completions';
 const VERCEL_AI_URL = RAW_VERCEL_AI_URL.startsWith('http') ? RAW_VERCEL_AI_URL : `https://${RAW_VERCEL_AI_URL}`;
-const REQUEST_TIMEOUT_MS = 5000;
-const VERCEL_AI_URL = process.env.VERCEL_AI_URL || 'https://ai-gateway.vercel.sh/v1/chat/completions';
 const DEFAULT_MODEL = process.env.VERCEL_MODEL || 'qwen/qwen3-32b';
 
 function withTimeout(url, options, timeoutMs = REQUEST_TIMEOUT_MS) {
@@ -76,18 +74,6 @@ module.exports = async function handler(req, res) {
             messages,
             temperature,
             ...(typeof max_tokens === 'number' ? { max_tokens } : {})
-        const response = await withTimeout(VERCEL_AI_URL, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                model,
-                messages,
-                temperature,
-                ...(typeof max_tokens === 'number' ? { max_tokens } : {})
-            })
         });
 
         if (!response.ok) {


### PR DESCRIPTION
### Motivation
- Prevent the Node process from crashing due to `SyntaxError: Identifier ... has already been declared` caused by duplicated constant declarations and an accidental duplicated request block in the AI handler.

### Description
- Remove duplicated `REQUEST_TIMEOUT_MS` and the redundant `VERCEL_AI_URL` assignment and keep the normalized `RAW_VERCEL_AI_URL` -> `VERCEL_AI_URL` flow.
- Eliminate the accidental inline `withTimeout` request block inside the `try` and use the existing `callProvider(apiKey, payload)` flow consistently.
- Restore a valid payload/object structure for the provider call so the file parses and runs correctly.
- Preserve existing behavior for `DEFAULT_MODEL`, API key lookup, and error handling logic.

### Testing
- Ran a syntax check with `node -c api/ai.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad14ce35648331a4f686138f7c00ea)