### PR TITLE
Corrige validação de login para nome completo ou código de acesso

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -40,6 +40,8 @@ document.addEventListener("DOMContentLoaded",()=>{
 
 window.getTodayStr=function(){const d=new Date();return d.getFullYear()+'-'+String(d.getMonth()+1).padStart(2,'0')+'-'+String(d.getDate()).padStart(2,'0');};
 
+window.normalizeUserKey=function(raw){return (raw||'').trim().toUpperCase().replace(/\s+/g,'_');};
+window.isValidAccessId=function(raw){const v=(raw||'').trim();return v.split(/\s+/).length>=2||/^[A-Za-z0-9_-]{3,32}$/.test(v);};
 
 
 window.showTab=function(id){
@@ -84,7 +86,7 @@ window.login = async function(isAuto) {
 
         const g = gEl ? gEl.value : '';
 
-        const n = nEl ? nEl.value.trim().toUpperCase() : '';
+        const rawIdentifier = nEl ? nEl.value.trim() : '';
 
         const p = pEl ? pEl.value.trim() : '';
 
@@ -92,17 +94,13 @@ window.login = async function(isAuto) {
 
 
 
-        if (!isAuto && (!g || n.split(' ').length < 2 || !/^[0-9]{8}$/.test(p))) {
-
-            return alert("Atenção: Selecione seu gênero, digite Nome e Sobrenome e a Senha (exatamente 8 números).");
-
+        if (!isAuto && (!g || !window.isValidAccessId(rawIdentifier) || !/^[0-9]{8}$/.test(p))) {
+            return alert("Atenção: Selecione seu gênero, digite Nome e Sobrenome ou Código de acesso, e a Senha (exatamente 8 números).");
         }
 
-
-
-        window.clientId = n.replace(/\s+/g, '_');
-
-        window.clientName = n.split(' ')[0];
+        const normalizedId = window.normalizeUserKey(rawIdentifier);
+        window.clientId = normalizedId;
+        window.clientName = rawIdentifier.split(/\s+/)[0] || 'Usuário';
 
 
 
@@ -118,7 +116,7 @@ window.login = async function(isAuto) {
 
             if (!snap.exists()) {
 
-                const newUser = { pass: p, fullName: n, gender: g || 'M', created: Date.now(), relacional: {}, saude: {}, financas: { transactions: [] } };
+                const newUser = { pass: p, fullName: rawIdentifier.toUpperCase(), gender: g || 'M', created: Date.now(), relacional: {}, saude: {}, financas: { transactions: [] } };
 
                 if (partnerCode) newUser.relacional.linkedPartner = partnerCode;
 
@@ -156,7 +154,7 @@ window.login = async function(isAuto) {
 
             window.userDataCache.pass = p;
 
-            window.userDataCache.fullName = n;
+            window.userDataCache.fullName = rawIdentifier.toUpperCase();
 
             window.userDataCache.gender = g || 'M';
 
@@ -172,7 +170,7 @@ window.login = async function(isAuto) {
 
             localStorage.setItem('wr_remember', 'true');
 
-            localStorage.setItem('wr_user', n);
+            localStorage.setItem('wr_user', rawIdentifier);
 
             localStorage.setItem('wr_pass', p);
 


### PR DESCRIPTION
### Motivation
- Resolver o bloqueio de alunos que usavam um código de acesso em vez de "Nome Sobrenome" no campo de identificação, que impedia o login no frontend.
- Padronizar a chave usada para identificar usuários no banco (evitar diferenças por espaços/maiúsculas) e reduzir inconsistências no Firebase.
- Preparar o fluxo para reduzir erros de UX ao armazenar o identificador em `localStorage` e em cache local.
- Identificar que a verificação de senha ainda ocorre no cliente e deve ser migrada para o servidor em uma próxima etapa.

### Description
- Adiciona `window.normalizeUserKey(raw)` para normalizar o identificador do usuário (trim, uppercase, espaços → `_`) e `window.isValidAccessId(raw)` para validar entrada como "Nome Sobrenome" ou código curto alfanumérico. (`js/app.js`).
- Altera `window.login` para ler o campo como `rawIdentifier`, validar ambos os formatos, gerar `window.clientId` com `normalizeUserKey` e definir `window.clientName` a partir do primeiro token informado. (`js/app.js`).
- Usa `rawIdentifier` ao criar `newUser.fullName`, ao popular o cache offline e ao gravar `wr_user` no `localStorage`, garantindo coerência entre entrada e armazenamento. (`js/app.js`).
- Atualiza a mensagem de validação exibida ao usuário para indicar que é aceito "Nome e Sobrenome" ou "Código de acesso". (`js/app.js`).

### Testing
- Executado `node --check js/app.js` para verificação sintática do arquivo modificado; resultado: sucesso.
- Rodado `rg -n "verifyPassword|AdminCredential|password_hash|LoginScreen.jsx"` para confirmar que não há a vulnerabilidade reportada no repositório atual; resultado: sem ocorrências no projeto.
- Verificações por `rg` e inspeção manual confirmaram as mudanças aplicadas em `js/app.js` e a ausência de `components/auth/LoginScreen.jsx` no código base; resultado: sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a019d1e55bc83319f7c97bd97239e6a)